### PR TITLE
add AWSCore 0.1 lower bound to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,9 @@
 julia 0.5
-AWSCore
+AWSCore 0.1
 HttpCommon
 Requests
 SymDict
 Retry
 XMLDict
 LightXML
+Nettle

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,6 @@ using AWSS3
 using Base.Test
 using Retry
 
-using Compat.readstring
-
 AWSCore.set_debug_level(1)
 
 function test_without_catch(f)


### PR DESCRIPTION
since it's the first version where AWSConfig is defined

also add direct dependency on Nettle which is imported but not
directly depended on (assumed to be present as transitive dep)

and remove vestigial use of Compat